### PR TITLE
Fix base32 decoding bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,14 +34,16 @@ function base32tohex(base32) {
 		bits = '',
 		hex = '';
 
+	base32 = base32.replace(/=+$/, '');
+
 	for(let i = 0; i < base32.length; i++) {
 		let val = base32chars.indexOf(base32.charAt(i).toUpperCase());
 		bits += leftpad(val.toString(2), 5, '0');
 	}
 
-	for(let i = 0; i + 4 <= bits.length; i += 4) {
-		let chunk = bits.substr(i, 4);
-		hex = hex + parseInt(chunk, 2).toString(16);
+	for(let i = 0; i + 8 <= bits.length; i += 8) {
+		let chunk = bits.substr(i, 8);
+		hex = hex + leftpad(parseInt(chunk, 2).toString(16), 2, '0');
 	}
 	return hex;
 }

--- a/index.js
+++ b/index.js
@@ -38,6 +38,7 @@ function base32tohex(base32) {
 
 	for(let i = 0; i < base32.length; i++) {
 		let val = base32chars.indexOf(base32.charAt(i).toUpperCase());
+		if (val === -1) throw new Error("Invalid base32 character in key");
 		bits += leftpad(val.toString(2), 5, '0');
 	}
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -18,9 +18,9 @@ describe('totp generation', () => {
 		expect(totp('JBSWY3DPEHPK3PXP')).toEqual('089029');
 	});
 
-	it('should generate token with date now = 2016', () => {
+	it('should generate token from a padded base32 key', () => {
 		global.Date.now = () => { return 1465324707000; };
-		expect(totp('JBSWY3DPEHPK3PXP')).toEqual('341128');
+		expect(totp('CI2FM6EQCI2FM6EQKU======')).toEqual('984195');
 	});
 
 	it('should generate longer-lasting token with date now = 2016', () => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -23,6 +23,11 @@ describe('totp generation', () => {
 		expect(totp('CI2FM6EQCI2FM6EQKU======')).toEqual('984195');
 	});
 
+	it('should throw if key contains an invalid character', () => {
+		global.Date.now = () => { return 1465324707000; };
+		expect(() => totp('JBSWY3DPEHPK3!@#')).toThrow("Invalid base32 character in key");
+	});
+
 	it('should generate longer-lasting token with date now = 2016', () => {
 		global.Date.now = () => { return 1465324707000; };
 		expect(totp('JBSWY3DPEHPK3PXP', {period: 60})).toEqual('313995');


### PR DESCRIPTION
This PR fixes TOTP generation when keys aren't a perfect multiple of 40 bits, such as the 256-bit keys used by Amazon and mentioned in #4.

To conform to [rfc4648](https://tools.ietf.org/html/rfc4648#section-6), the for loop calculating the hex representation of the key now works with 8-bit chunks, not 4. This is because it's illegal for base32 input to be a fractional number of bytes, so we must ignore any bits left over at the end of the decoded string.

I also took the opportunity to throw a more appropriate error when the key contains invalid characters.