### PR TITLE
Add an option to pass custom time

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ console.log(token); // prints a token created using a different algorithm
 const token = totp("JBSWY3DPEHPK3PXP", { period: 60 });
 console.log(token); // prints a token using a 60-second epoch interval
 
+const token = totp("JBSWY3DPEHPK3PXP", { timestamp: 1465324707000 });
+console.log(token); // prints a token for given time
+
 const token = totp("JBSWY3DPEHPK3PXP", {
 	digits: 8,
 	algorithm: "SHA-512",
 	period: 60,
+	timestamp: 1465324707000,
 });
 console.log(token); // prints a token using all custom settings combined
 ```

--- a/index.js
+++ b/index.js
@@ -8,8 +8,9 @@ module.exports = function getToken(key, options) {
 	options.period = options.period || 30;
 	options.algorithm = options.algorithm || 'SHA-1';
 	options.digits = options.digits || 6;
+	options.timestamp = options.timestamp || Date.now();
 	key = base32tohex(key);
-	epoch = Math.round(Date.now() / 1000.0);
+	epoch = Math.round(options.timestamp / 1000.0);
 	time = leftpad(dec2hex(Math.floor(epoch / options.period)), 16, '0');
 	shaObj = new JsSHA(options.algorithm, 'HEX');
 	shaObj.setHMACKey(key, 'HEX');

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -42,4 +42,8 @@ describe('totp generation', () => {
 		global.Date.now = () => { return 1465324707000; };
 		expect(totp('JBSWY3DPEHPK3PXP', {algorithm: 'SHA-512'})).toEqual('093730');
 	});
+
+	it('should generate token with timestamp from options', () => {
+		expect(totp('JBSWY3DPEHPK3PXP', {timestamp: 1465324707000 })).toEqual('341128');
+	});
 });


### PR DESCRIPTION
Some implementations like for specific Authy requests need passing 3 TOTP codes (in the case of Authy, one for now, one for now + interval, and one for now + 2 x interval.

This PR implements a `now` option to allow for this use case. Let me know of you prefer a different name or of it'd make more sense to pass the already rounded epoch in seconds instead of the milliseconds time and I'll update the PR accordingly!

If you don't think this option is relevant to the project feel free to close, I can still monkey patch `Date.now` like in the tests but I'd rather avoid using this trick in production unless I really need to. :P

Thanks!