### PR TITLE
fix: use floor instead of rounding off timestamp

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function getToken(key, options) {
 	options.digits = options.digits || 6
 	options.timestamp = options.timestamp || Date.now()
 	key = base32tohex(key)
-	epoch = Math.round(options.timestamp / 1000.0)
+	epoch = Math.floor(options.timestamp / 1000.0)
 	time = leftpad(dec2hex(Math.floor(epoch / options.period)), 16, "0")
 	shaObj = new JsSHA(options.algorithm, "HEX")
 	shaObj.setHMACKey(key, "HEX")

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -13,6 +13,16 @@ describe("totp generation", () => {
 		expect(totp("JBSWY3DPEHPK3PXP")).toEqual("341128")
 	})
 
+	it("should generate correct token at the start of the cycle", () => {
+		global.Date.now = () => 1665644340100
+		expect(totp("JBSWY3DPEHPK3PXP")).toEqual("886842")
+	})
+
+	it("should generate correct token at the end of the cycle", () => {
+		global.Date.now = () => 1665644339900
+		expect(totp("JBSWY3DPEHPK3PXP")).toEqual("134996")
+	})
+
 	it("should generate token with a leading zero", () => {
 		global.Date.now = () => 1365324707000
 		expect(totp("JBSWY3DPEHPK3PXP")).toEqual("089029")


### PR DESCRIPTION
this is to prevent calculation of TOTP for next cycle in the last 500 ms of the current cycle due to round off