### PR TITLE
feat(crypto): Add universal support via jssha fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,8 @@
         "statements": 100
       }
     }
+  },
+  "dependencies": {
+    "jssha": "^3.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,6 +2220,11 @@ json5@^2.2.3:
   resolved "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jssha@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/jssha/-/jssha-3.3.1.tgz#c5b7fc7fb9aa745461923b87df0e247dd59c7ea8"
+  integrity sha512-VCMZj12FCFMQYcFLPRm/0lOBbLi8uM2BhXPTqw3U4YAfs4AZfiApOoBLoN8cQE60Z50m1MYMTQVCfgF/KaCVhQ==
+
 leven@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz"


### PR DESCRIPTION
This PR resolves the critical issue where the library would crash in React Native environments (like Expo) after the move to the native Web Crypto API. The library is now truly universal, running seamlessly across Node.js, browsers, and React Native without requiring any special configuration from the end-user.

### The Problem

The previous version relied on `globalThis.crypto` or `require("node:crypto").webcrypto`. While this was a great performance improvement for standard environments, it caused a build failure in React Native, where the `node:crypto` module is not available.

### The Solution

Instead of maintaining separate platform-specific files, this PR implements a more robust, unified strategy:

- Native-First Approach: The code always attempts to use the fast, native Web Crypto API first.

- Graceful Fallback: If the native API is unavailable (detected via a try...catch block), the library seamlessly falls back to a pure JavaScript implementation using jssha.

- Optimized Bundle Size: The jssha fallback is loaded using a dynamic import(). This means it's code-split into a separate chunk and is only loaded in the environments that actually need it, keeping the library lightweight for the majority of users.

This approach provides the best of all worlds: native performance where available, and universal compatibility where it's not.

Key Changes:

- Refactored TOTP class: The core signing logic has been moved to a private _sign method which contains the fallback mechanism.

- Added jssha: The jssha library has been added as a direct dependency to serve as the crypto fallback.

- Updated Test Suite: The Jest tests have been updated to verify the fallback logic. A new `describe("fallback environments")` block now simulates an environment where native crypto is absent to confirm that the jssha path is correctly triggered and produces the exact same output.

This PR ensures the library is both modern and maximally compatible.